### PR TITLE
Handle endpoint authorization failure

### DIFF
--- a/src/converters/index.ts
+++ b/src/converters/index.ts
@@ -4,9 +4,5 @@ export { createGroupEntities } from "./GroupEntityConverter";
 export { createSiteEntities } from "./SiteEntityConverter";
 export { createUserGroupRelationships } from "./UserGroupRelationshipConverter";
 export { createSiteUserRelationships } from "./SiteUserRelationshipConverter";
-export {
-  createAccountUserRelationships,
-} from "./AccountUserRelationshipConverter";
-export {
-  createAccountGroupRelationships,
-} from "./AccountGroupRelationshipConverter";
+export { createAccountUserRelationships } from "./AccountUserRelationshipConverter";
+export { createAccountGroupRelationships } from "./AccountGroupRelationshipConverter";


### PR DESCRIPTION
This allows the error, logging as warn, and returns no response, which the client assumes to mean there are no resources, and returns an empty collection. When access is had, but then lost, the data will be deleted.