### PR TITLE
Fixes #70 - Only use default scopes that GSuiteClient unless

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,16 +3,19 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
+      matrix:
+        node-version: [12.x]
+        os: [ubuntu-latest]
 
     steps:
       - id: setup-node
         name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: ${{ matrix.node-version }}
 
       - name: Check out code repository source code
         uses: actions/checkout@v2
@@ -32,6 +35,8 @@ jobs:
     if: github.ref == 'refs/heads/master'
     strategy:
       fail-fast: false
+      matrix:
+        node: [12]
 
     steps:
       - name: Setup Node

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## 3.1.1 - 2020-09-04
+
 ### Fixed
 
 - [#70](https://github.com/JupiterOne/graph-google/issues/70) - Step

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- [#70](https://github.com/JupiterOne/graph-google/issues/70) - Step
+  authorization should handle missing OAuth scopes
+
 ## 3.1.0 - 2020-08-31
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-google",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "A JupiterOne managed integration for Google",
   "license": "MPL-2.0",
   "main": "dist/index.js",

--- a/src/gsuite/clients/GSuiteClient.test.ts
+++ b/src/gsuite/clients/GSuiteClient.test.ts
@@ -91,7 +91,7 @@ describe('GSuiteClient.getAuthenticatedServiceClient', () => {
     await expect(
       gsuiteClient.getAuthenticatedServiceClient(),
     ).rejects.toThrowError(
-      'Provider authorization failed at https://www.googleapis.com/oauth2/v4/token: 401 Client is unauthorized to retrieve access tokens using this method, or client not authorized for any of the scopes requested. Please ensure that your API client in GSuite has the correct scopes. See the GSuite integration docs here: https://github.com/JupiterOne/graph-google/blob/master/docs/jupiterone.md#admin-api-enablement (scopes=https://www.googleapis.com/auth/admin.directory.user.readonly, https://www.googleapis.com/auth/admin.directory.group.readonly, https://www.googleapis.com/auth/admin.directory.domain.readonly)',
+      'Provider authorization failed at https://www.googleapis.com/oauth2/v4/token: 401 Client is unauthorized to retrieve access tokens using this method, or client not authorized for any of the scopes requested. Please ensure that your API client in GSuite has the correct scopes. See the GSuite integration docs here: https://github.com/JupiterOne/graph-google/blob/master/docs/jupiterone.md#admin-api-enablement (requiredScopes=https://www.googleapis.com/auth/admin.directory.user.readonly, https://www.googleapis.com/auth/admin.directory.group.readonly, https://www.googleapis.com/auth/admin.directory.domain.readonly)',
     );
   });
 

--- a/src/gsuite/clients/GSuiteClient.test.ts
+++ b/src/gsuite/clients/GSuiteClient.test.ts
@@ -1,0 +1,123 @@
+import GSuiteClient from './GSuiteClient';
+import { google } from 'googleapis';
+import { Credentials } from 'google-auth-library';
+import { admin_directory_v1 } from 'googleapis';
+import { createMockIntegrationLogger } from '@jupiterone/integration-sdk-testing';
+
+import { getMockIntegrationConfig } from '../../../test/config';
+
+function getMockCredentials(): Credentials {
+  return {};
+}
+
+describe('GSuiteClient.getAuthenticatedServiceClient', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('should allow authorizing a new client', async () => {
+    const instanceConfig = getMockIntegrationConfig();
+
+    jest.spyOn(google.auth, 'JWT').mockReturnValueOnce({
+      authorize: () => Promise.resolve(getMockCredentials()),
+    } as any);
+
+    const gsuiteClient = new GSuiteClient({
+      config: instanceConfig,
+      logger: createMockIntegrationLogger(),
+    });
+
+    const client = await gsuiteClient.getAuthenticatedServiceClient();
+
+    expect(client instanceof admin_directory_v1.Admin).toEqual(true);
+    expect(gsuiteClient.requiredScopes).toEqual([
+      'https://www.googleapis.com/auth/admin.directory.user.readonly',
+      'https://www.googleapis.com/auth/admin.directory.group.readonly',
+      'https://www.googleapis.com/auth/admin.directory.domain.readonly',
+    ]);
+  });
+
+  test('should allow passing custom oauth scopes and dedup', async () => {
+    const instanceConfig = getMockIntegrationConfig();
+
+    jest.spyOn(google.auth, 'JWT').mockReturnValueOnce({
+      authorize: () => Promise.resolve(getMockCredentials()),
+    } as any);
+
+    const gsuiteClient = new GSuiteClient({
+      config: instanceConfig,
+      logger: createMockIntegrationLogger(),
+      requiredScopes: [
+        'https://www.googleapis.com/auth/admin.directory.group.readonly',
+        'https://www.googleapis.com/auth/admin.directory.user.security',
+      ],
+    });
+
+    const client = await gsuiteClient.getAuthenticatedServiceClient();
+
+    expect(client instanceof admin_directory_v1.Admin).toEqual(true);
+    expect(gsuiteClient.requiredScopes).toEqual([
+      'https://www.googleapis.com/auth/admin.directory.user.readonly',
+      'https://www.googleapis.com/auth/admin.directory.group.readonly',
+      'https://www.googleapis.com/auth/admin.directory.domain.readonly',
+      'https://www.googleapis.com/auth/admin.directory.user.security',
+    ]);
+  });
+
+  test('should throw if authorize function throws', async () => {
+    const instanceConfig = getMockIntegrationConfig();
+    const mockResponseError = new Error('Mock error authorizing');
+
+    (mockResponseError as any).response = {
+      data: {
+        error: 'unauthorized_client',
+        error_description:
+          'Client is unauthorized to retrieve access tokens using this method, or client not authorized for any of the scopes requested.',
+      },
+      status: 401,
+      statusText: 'Unauthorized',
+      request: { responseURL: 'https://www.googleapis.com/oauth2/v4/token' },
+    };
+
+    jest.spyOn(google.auth, 'JWT').mockReturnValueOnce({
+      authorize: () => Promise.reject(mockResponseError),
+    } as any);
+
+    const gsuiteClient = new GSuiteClient({
+      config: instanceConfig,
+      logger: createMockIntegrationLogger(),
+    });
+
+    await expect(
+      gsuiteClient.getAuthenticatedServiceClient(),
+    ).rejects.toThrowError(
+      'Provider authorization failed at https://www.googleapis.com/oauth2/v4/token: 401 Client is unauthorized to retrieve access tokens using this method, or client not authorized for any of the scopes requested. Please ensure that your API client in GSuite has the correct scopes. See the GSuite integration docs here: https://github.com/JupiterOne/graph-google/blob/master/docs/jupiterone.md#admin-api-enablement (scopes=https://www.googleapis.com/auth/admin.directory.user.readonly, https://www.googleapis.com/auth/admin.directory.group.readonly, https://www.googleapis.com/auth/admin.directory.domain.readonly)',
+    );
+  });
+
+  test('should reuse existing client if called twice', async () => {
+    const instanceConfig = getMockIntegrationConfig();
+
+    const authorizeMockFn = jest
+      .fn()
+      .mockResolvedValueOnce(Promise.resolve(getMockCredentials()))
+      .mockRejectedValueOnce(new Error('Should not call twice'));
+
+    jest.spyOn(google.auth, 'JWT').mockReturnValue({
+      authorize: authorizeMockFn,
+    } as any);
+
+    const gsuiteClient = new GSuiteClient({
+      config: instanceConfig,
+      logger: createMockIntegrationLogger(),
+    });
+
+    const client = await gsuiteClient.getAuthenticatedServiceClient();
+    const client1 = await gsuiteClient.getAuthenticatedServiceClient();
+
+    expect(client instanceof admin_directory_v1.Admin).toEqual(true);
+    expect(client1 instanceof admin_directory_v1.Admin).toEqual(true);
+    expect(authorizeMockFn).toHaveBeenCalledTimes(1);
+    expect(client).toBe(client1);
+  });
+});

--- a/src/gsuite/clients/GSuiteClient.ts
+++ b/src/gsuite/clients/GSuiteClient.ts
@@ -34,7 +34,7 @@ const DEFAULT_GSUITE_OAUTH_SCOPES: string[] = [
 export default class GSuiteClient {
   readonly accountId: string;
   readonly logger: IntegrationLogger;
-  readonly requiredScopes: string[] = DEFAULT_GSUITE_OAUTH_SCOPES;
+  readonly requiredScopes: string[];
 
   private client: admin_directory_v1.Admin;
   private credentials: JWTOptions;
@@ -48,7 +48,7 @@ export default class GSuiteClient {
     this.accountId = config.googleAccountId;
 
     this.requiredScopes = Array.from(
-      new Set([...this.requiredScopes, ...requiredScopes]),
+      new Set([...DEFAULT_GSUITE_OAUTH_SCOPES, ...requiredScopes]),
     );
 
     this.credentials = {
@@ -71,7 +71,7 @@ export default class GSuiteClient {
       const endpoint = err.response?.request?.responseURL;
       const statusText = `${
         err.response?.data?.error_description
-      } Please ensure that your API client in GSuite has the correct scopes. See the GSuite integration docs here: https://github.com/JupiterOne/graph-google/blob/master/docs/jupiterone.md#admin-api-enablement (scopes=${Array.from(
+      } Please ensure that your API client in GSuite has the correct scopes. See the GSuite integration docs here: https://github.com/JupiterOne/graph-google/blob/master/docs/jupiterone.md#admin-api-enablement (requiredScopes=${Array.from(
         this.requiredScopes,
       ).join(', ')})`;
 

--- a/src/gsuite/clients/GSuiteTokenClient.ts
+++ b/src/gsuite/clients/GSuiteTokenClient.ts
@@ -1,8 +1,17 @@
-import GSuiteClient from './GSuiteClient';
+import GSuiteClient, { CreateGSuiteClientParams } from './GSuiteClient';
 
 import { admin_directory_v1 } from 'googleapis';
 
 export class GSuiteTokenClient extends GSuiteClient {
+  constructor(params: CreateGSuiteClientParams) {
+    super({
+      ...params,
+      requiredScopes: [
+        'https://www.googleapis.com/auth/admin.directory.user.security',
+      ],
+    });
+  }
+
   async iterateTokens(
     userKey: string,
     callback: (data: admin_directory_v1.Schema$Token) => Promise<void>,

--- a/src/gsuite/clients/GSuiteTokenClient.ts
+++ b/src/gsuite/clients/GSuiteTokenClient.ts
@@ -22,12 +22,11 @@ export class GSuiteTokenClient extends GSuiteClient {
     try {
       ({ data: tokenResponse } = await client.tokens.list({ userKey }));
     } catch (err) {
-      this.logger.warn(
-        {
-          err,
-        },
-        `Could not list tokens for user. NOTE: The tokens of users who have higher permissions than the domain admin used by this integration cannot be listed.`,
-      );
+      this.logger.warn({ err }, 'Could not list tokens for user');
+      this.logger.publishEvent({
+        name: 'list_token_error',
+        description: `Could not list tokens for user. NOTE: The tokens of users who have higher permissions than the domain admin used by this integration cannot be listed.`,
+      });
       return;
     }
 

--- a/src/steps/tokens/index.ts
+++ b/src/steps/tokens/index.ts
@@ -42,11 +42,13 @@ export async function fetchTokens(
     );
   } catch (err) {
     if (err instanceof IntegrationProviderAuthorizationError) {
-      context.logger.warn(
-        `Could not ingest token entities. Missing required scope(s) (scopes=${client.requiredScopes.join(
+      context.logger.warn({ err }, 'Could not ingest token entities');
+      context.logger.publishEvent({
+        name: 'missing_scope',
+        description: `Could not ingest token entities. Missing required scope(s) (scopes=${client.requiredScopes.join(
           ', ',
         )})`,
-      );
+      });
       return;
     }
 

--- a/src/validateInvocation.ts
+++ b/src/validateInvocation.ts
@@ -1,7 +1,6 @@
 import {
   IntegrationExecutionContext,
   IntegrationConfigLoadError,
-  IntegrationProviderAuthenticationError,
 } from '@jupiterone/integration-sdk-core';
 
 import { IntegrationConfig } from './types';
@@ -33,10 +32,5 @@ export default async function validateInvocation(
   ));
 
   const client = new GSuiteClient({ config, logger });
-
-  try {
-    await client.getAuthenticatedServiceClient();
-  } catch (err) {
-    throw new IntegrationProviderAuthenticationError(err);
-  }
+  await client.getAuthenticatedServiceClient();
 }


### PR DESCRIPTION
additional scopes explicitly passed into GSuiteClient. Include additional information in error messages. Log more useful warning when attempting to read tokens without correct permission.