### PR TITLE
Adds mapped AccessKey -ALLOWS-> Vendor relationship

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Create relationship mapping from google_token Entities to Vendor entities
+
 ## 3.1.3 - 2020-09-24
 
 ### Fixed

--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -123,14 +123,15 @@ The following entities are created:
 
 The following relationships are created/mapped:
 
-| Source Entity `_type` | Relationship `_class` | Target Entity `_type` |
-| --------------------- | --------------------- | --------------------- |
-| `google_group`        | **HAS**               | `google_user`         |
-| `google_group`        | **HAS**               | `google_group`        |
-| `google_account`      | **HAS**               | `google_group`        |
-| `google_account`      | **HAS**               | `google_user`         |
-| `google_site`         | **HAS**               | `google_user`         |
-| `google_user`         | **ASSIGNED**          | `google_token`        |
+| Source Entity `_type` | Relationship `_class` | Target Entity `_type`          |
+| --------------------- | --------------------- | ------------------------------ |
+| `google_group`        | **HAS**               | `google_user`                  |
+| `google_group`        | **HAS**               | `google_group`                 |
+| `google_account`      | **HAS**               | `google_group`                 |
+| `google_account`      | **HAS**               | `google_user`                  |
+| `google_site`         | **HAS**               | `google_user`                  |
+| `google_user`         | **ASSIGNED**          | `google_token`                 |
+| `google_token`        | **ALLOWS**            | `mapped_entity (class Vendor)` |
 
 <!--
 ********************************************************************************

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -51,7 +51,8 @@ type RelationshipConstantKeys =
   | 'GROUP_HAS_USER'
   | 'GROUP_HAS_GROUP'
   | 'ACCOUNT_HAS_GROUP'
-  | 'USER_ASSIGNED_TOKEN';
+  | 'USER_ASSIGNED_TOKEN'
+  | 'TOKEN_ALLOWS_VENDOR';
 
 export const relationships: Record<
   RelationshipConstantKeys,
@@ -93,5 +94,11 @@ export const relationships: Record<
     _class: RelationshipClass.ASSIGNED,
     sourceType: entities.USER._type,
     targetType: entities.TOKEN._type,
+  },
+  TOKEN_ALLOWS_VENDOR: {
+    _type: 'google_token_allows_mapped_vendor',
+    _class: RelationshipClass.ALLOWS,
+    sourceType: entities.TOKEN._type,
+    targetType: 'mapped_entity (class Vendor)',
   },
 };

--- a/src/steps/tokens/index.ts
+++ b/src/steps/tokens/index.ts
@@ -1,6 +1,9 @@
 import {
   IntegrationStep,
   IntegrationProviderAuthorizationError,
+  createMappedRelationship,
+  RelationshipClass,
+  RelationshipDirection,
 } from '@jupiterone/integration-sdk-core';
 import { IntegrationConfig, IntegrationStepContext } from '../../types';
 import { entities, relationships } from '../../constants';
@@ -37,6 +40,24 @@ export async function fetchTokens(
               tokenEntity,
             }),
           );
+          await jobState.addRelationship(
+            createMappedRelationship({
+              _class: RelationshipClass.ALLOWS,
+              _type: relationships.TOKEN_ALLOWS_VENDOR._type,
+              _mapping: {
+                sourceEntityKey: tokenEntity._key,
+                relationshipDirection: RelationshipDirection.FORWARD,
+                targetFilterKeys: [['_class', 'name']],
+                targetEntity: {
+                  _class: 'Vendor',
+                  displayName: token.displayText || undefined,
+                  name: token.displayText || undefined,
+                  validated: false,
+                  active: true,
+                },
+              },
+            }),
+          );
         });
       },
     );
@@ -61,7 +82,10 @@ export const tokenSteps: IntegrationStep<IntegrationConfig>[] = [
     id: 'step-fetch-tokens',
     name: 'Tokens',
     entities: [entities.TOKEN],
-    relationships: [relationships.USER_ASSIGNED_TOKEN],
+    relationships: [
+      relationships.USER_ASSIGNED_TOKEN,
+      relationships.TOKEN_ALLOWS_VENDOR,
+    ],
     dependsOn: ['step-fetch-users'],
     executionHandler: fetchTokens,
   },

--- a/src/steps/tokens/index.ts
+++ b/src/steps/tokens/index.ts
@@ -50,8 +50,8 @@ export async function fetchTokens(
                 targetFilterKeys: [['_class', 'name']],
                 targetEntity: {
                   _class: 'Vendor',
-                  displayName: token.displayText || undefined,
-                  name: token.displayText || undefined,
+                  displayName: token.displayText || 'Unknown Vendor',
+                  name: token.displayText || 'Unknown Vendor',
                   validated: false,
                   active: true,
                 },


### PR DESCRIPTION
The google_token entities almost certainly represent external Vendor
relationships that the customer/company has started using. This change
surfaces that by creating Vendor entities if they do not already exist,
with a default validated: state of false and active: state of true.

This allows for easy, albeit lightweight, Vendor management in J1.