### PR TITLE
AB#2098 -  Add error handling to Google api calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## 3.3.2 - 2021-01-11
+
+## Added
+
+- Error handling for API errors.
+
 ## 3.3.1 - 2020-11-12
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-google",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "A JupiterOne managed integration for Google",
   "license": "MPL-2.0",
   "main": "dist/index.js",

--- a/src/gsuite/clients/utils/createErrorProps.ts
+++ b/src/gsuite/clients/utils/createErrorProps.ts
@@ -1,0 +1,27 @@
+import { IntegrationProviderAPIError } from '@jupiterone/integration-sdk-core';
+import { GaxiosError } from 'gaxios';
+
+const UNKNOWN_VALUE = 'UNKNOWN';
+
+type J1ApiErrorProps = GetConstructorArgs<
+  typeof IntegrationProviderAPIError
+>[0];
+
+export function createErrorProps(error: Error | GaxiosError): J1ApiErrorProps {
+  if (error instanceof GaxiosError && error.response) {
+    return {
+      cause: error,
+      endpoint: error.response?.config?.url || UNKNOWN_VALUE,
+      status: error.response?.status,
+      statusText: error.response?.statusText,
+    };
+  } else {
+    return {
+      // If it isn't GaxiosError, not sure what the args are so just take the error and move on
+      cause: error,
+      endpoint: UNKNOWN_VALUE,
+      status: UNKNOWN_VALUE,
+      statusText: UNKNOWN_VALUE,
+    };
+  }
+}

--- a/src/gsuite/clients/utils/createErrorProps.ts
+++ b/src/gsuite/clients/utils/createErrorProps.ts
@@ -1,5 +1,6 @@
 import { IntegrationProviderAPIError } from '@jupiterone/integration-sdk-core';
 import { GaxiosError } from 'gaxios';
+import { GetConstructorArgs } from './typeFunctions';
 
 const UNKNOWN_VALUE = 'UNKNOWN';
 

--- a/src/gsuite/clients/utils/typeFunctions.ts
+++ b/src/gsuite/clients/utils/typeFunctions.ts
@@ -1,0 +1,8 @@
+/**
+ * Pulls all props to be passed into a constructor.
+ * EXAMPLE:
+ * GetConstructorArgs<typeof Error> === [message: string | undefined]
+ */
+type GetConstructorArgs<T> = T extends new (...args: infer U) => any
+  ? U
+  : never;

--- a/src/gsuite/clients/utils/typeFunctions.ts
+++ b/src/gsuite/clients/utils/typeFunctions.ts
@@ -3,6 +3,6 @@
  * EXAMPLE:
  * GetConstructorArgs<typeof Error> === [message: string | undefined]
  */
-type GetConstructorArgs<T> = T extends new (...args: infer U) => any
+export type GetConstructorArgs<T> = T extends new (...args: infer U) => any
   ? U
   : never;


### PR DESCRIPTION
If an error code thrown by the Google sdk is 401 or 403, throw an `IntegrationProviderAuthorizationError`, otherwise throw an `IntegrationProviderAPIError`