### PR TITLE
Update @jupiterone/integration-sdk-*@5.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+- Update to `@jupiterone/integration-sdk-*@5.6.1`
+
 ## 3.3.2 - 2021-01-11
 
 ## Added

--- a/package.json
+++ b/package.json
@@ -25,12 +25,12 @@
     "prepack": "yarn build"
   },
   "peerDependencies": {
-    "@jupiterone/integration-sdk-core": "^4.0.0"
+    "@jupiterone/integration-sdk-core": "^5.6.1"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-core": "^4.0.0",
-    "@jupiterone/integration-sdk-dev-tools": "^4.0.0",
-    "@jupiterone/integration-sdk-testing": "^4.0.0",
+    "@jupiterone/integration-sdk-core": "^5.6.1",
+    "@jupiterone/integration-sdk-dev-tools": "^5.6.1",
+    "@jupiterone/integration-sdk-testing": "^5.6.1",
     "dotenv": "^8.2.0",
     "ts-node": "^8.10.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -468,19 +468,19 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@jupiterone/data-model@^0.14.0":
-  version "0.14.1"
-  resolved "https://registry.yarnpkg.com/@jupiterone/data-model/-/data-model-0.14.1.tgz#cd2692a3c16ce6213f296b5f56c58e469e006728"
-  integrity sha512-8E6KDtl8bhz23MQA+1yUr4Amm28ync4+2yfUYOK7M0KkDLGtub8wJ5at3vgZFCk4Xx2oQBa78cstZGrK+ko/hA==
+"@jupiterone/data-model@^0.15.0":
+  version "0.15.1"
+  resolved "https://registry.yarnpkg.com/@jupiterone/data-model/-/data-model-0.15.1.tgz#382fa7d861afb1f298bc06a60bca651193952198"
+  integrity sha512-Vz569gnXoMI9aDVNlUsk8yo858YElnzP6hx606MtYCSvaVRstqAdcKawlhART+z1msnw6A5evw9qLkQQzMoD1A==
   dependencies:
     ajv "^6.12.0"
 
-"@jupiterone/integration-sdk-cli@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-cli/-/integration-sdk-cli-4.0.0.tgz#6681141c97338c836159f93928fa83f0b6f607b4"
-  integrity sha512-/oScZpt3emFLmIOvFWaDy+8GKOm7c36ZVEqDOm0pdCQZD48/5az/t4c5ZlCA9Fe5Dnih0p8DDTasZW3tumSjQw==
+"@jupiterone/integration-sdk-cli@^5.6.1":
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-cli/-/integration-sdk-cli-5.6.1.tgz#7c16043152c1e75dd307a5049578af0955ca5b33"
+  integrity sha512-ED6xZsaEyH5YGj3pDQwOghCaIC9KXKXVAxgXuN7sA35u/1S+Nivpsk9iJkvEW1SrFvaivHD3uTAeviZNiEb8OA==
   dependencies:
-    "@jupiterone/integration-sdk-runtime" "^4.0.0"
+    "@jupiterone/integration-sdk-runtime" "^5.6.1"
     commander "^5.0.0"
     globby "^11.0.0"
     lodash "^4.17.19"
@@ -488,22 +488,22 @@
     upath "^1.2.0"
     vis "^4.21.0-EOL"
 
-"@jupiterone/integration-sdk-core@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-core/-/integration-sdk-core-4.0.0.tgz#eb34f153d2cd7317516283866520efa56820c233"
-  integrity sha512-n6nKco6dOUfrqUcya/wvaz+NndjNYqEHhkZIHwxdxtZ5A8UzLLZr9f8fP/KMkUXiNahnFxBBYuukx4q+UcnOPQ==
+"@jupiterone/integration-sdk-core@^5.6.1":
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-core/-/integration-sdk-core-5.6.1.tgz#df4831c23381130afef608849e99111c3bc3752c"
+  integrity sha512-PJIzCxvQOTHfIhy037056rClKVA891j+SaqdLlmjmMYotm9Uax2zwkRXnBYHhEzSw6/IJzs/nNGS1ftsRKYZ8A==
   dependencies:
-    "@jupiterone/data-model" "^0.14.0"
+    "@jupiterone/data-model" "^0.15.0"
     lodash "^4.17.15"
     uuid "^7.0.3"
 
-"@jupiterone/integration-sdk-dev-tools@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-dev-tools/-/integration-sdk-dev-tools-4.0.0.tgz#99e8bd4f12f563c6adf168366dc0868d821ae497"
-  integrity sha512-wq3EckcWlB0g1fq5JG5MMnq7qlsoR2axAHMukA5VbK2GBbDda6w7T6wYpa8pjgFfxvQoqn8XTH6bLwhgThGmfQ==
+"@jupiterone/integration-sdk-dev-tools@^5.6.1":
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-dev-tools/-/integration-sdk-dev-tools-5.6.1.tgz#9352b489711eaf1526543933ad6f870fe46def10"
+  integrity sha512-AQ5O7DIbdjYrWa9/Esc3BWQ91jbfeFmb0sY9DtvNUXOgdsdcp/dS1n8M3sJqhPaxGHZgMZwwf/qKumK264+RrA==
   dependencies:
-    "@jupiterone/integration-sdk-cli" "^4.0.0"
-    "@jupiterone/integration-sdk-testing" "^4.0.0"
+    "@jupiterone/integration-sdk-cli" "^5.6.1"
+    "@jupiterone/integration-sdk-testing" "^5.6.1"
     "@types/jest" "^25.2.3"
     "@types/node" "^14.0.5"
     "@typescript-eslint/eslint-plugin" "^3.8.0"
@@ -519,13 +519,14 @@
     ts-node "^8.10.2"
     typescript "^3.9.3"
 
-"@jupiterone/integration-sdk-runtime@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-runtime/-/integration-sdk-runtime-4.0.0.tgz#2bef58476b24c6fbc625f84ae6426f65eb45f105"
-  integrity sha512-iadYr13kKuru0Yhbp6H5Ayc4gcp3uEw13WwxlUXBDH87ZDD3B+zV/xNNS2J2xQ22DK3YW2tXdjae46vTf70q2g==
+"@jupiterone/integration-sdk-runtime@^5.6.1":
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-runtime/-/integration-sdk-runtime-5.6.1.tgz#fcd5f7ce495bd11b3f979316db1c8a4865eabd07"
+  integrity sha512-FqJgm1MuTw/IlI+gWQy7i5u6WumS3f9cbw8oWJfjvUHQqvgfPycHltVwmqxIc0SSJXXKTooKikGi79Ba1r+Wig==
   dependencies:
-    "@jupiterone/integration-sdk-core" "^4.0.0"
+    "@jupiterone/integration-sdk-core" "^5.6.1"
     "@lifeomic/alpha" "^1.1.3"
+    "@lifeomic/attempt" "^3.0.0"
     async-sema "^3.1.0"
     axios "^0.19.2"
     bunyan "^1.8.12"
@@ -541,13 +542,13 @@
     rimraf "^3.0.2"
     uuid "^7.0.3"
 
-"@jupiterone/integration-sdk-testing@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-testing/-/integration-sdk-testing-4.0.0.tgz#23edeb96b91f3d09533a9d0187b0007b2cc0ac7f"
-  integrity sha512-DGbvmIb/MBIRsJEQeVWjZ9fu1E955ALxLijBQS8nBNZ9MYP7PqexA5fwJM24Z0hIv6EeZt1E9LCJXUf50+ZloA==
+"@jupiterone/integration-sdk-testing@^5.6.1":
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-testing/-/integration-sdk-testing-5.6.1.tgz#cd6be6ca3414e305237550d915af30cde7cfa787"
+  integrity sha512-7fwlEky4+RnLpgG+Jo7YchqExY5SbxQnrsfGpNvW6+yPGZk3jsWAQoAb0A35Z8LsWpA4oWO+Bzu5beZtBs+9Qw==
   dependencies:
-    "@jupiterone/integration-sdk-core" "^4.0.0"
-    "@jupiterone/integration-sdk-runtime" "^4.0.0"
+    "@jupiterone/integration-sdk-core" "^5.6.1"
+    "@jupiterone/integration-sdk-runtime" "^5.6.1"
     "@pollyjs/adapter-node-http" "^4.0.4"
     "@pollyjs/core" "^4.0.4"
     "@pollyjs/persister-fs" "^4.0.4"
@@ -570,6 +571,11 @@
     nearley "^2.16.0"
     resolve-pathname "^3.0.0"
     url-parse "^1.4.7"
+
+"@lifeomic/attempt@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@lifeomic/attempt/-/attempt-3.0.0.tgz#75fecc204f8b0ac18b5363b4404bb32450f01859"
+  integrity sha512-Ibk4Vfl46dSrhtH5fHsrTA4waAuyP7/qcr3uo0mO70azRc6LWgJILlMy3B1oOvyiN9jQcdqwsThaQkPKLiYKTg==
 
 "@nodelib/fs.scandir@2.1.3":
   version "2.1.3"


### PR DESCRIPTION
Upgrading for new release that will move to ECS, expecting to use the latest managed runtime.