### PR TITLE
INT-1715: Ingest Google admin roles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 .env
 .eslintcache
 tsconfig.tsbuildinfo
+.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- New entity added (_**ACTION REQUIRED**_):
+
+  | Resources | Entity `_type` | Entity `_class` |
+  | --------- | -------------- | --------------- |
+  | Role      | `google_role`  | `AccessRole`    |
+
+  Log into the Google Workspace **Admin Console** as a super administrator to
+  perform the following actions.
+
+  1. Click **Security** > **API controls**.
+  2. In the **Domain wide delegation** pane, select **Manage Domain Wide
+     Delegation**.
+  3. Click **Edit** near the JupiterOne Service Account and add a new entry
+     under **API scopes** for
+     `https://www.googleapis.com/auth/admin.directory.rolemanagement.readonly`
+
 ## 3.8.0 - 2021-08-25
 
 ### Added

--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -72,7 +72,7 @@ perform the following actions.
 5. Add the following **API scopes** (comma separated):
 
    ```text
-   https://www.googleapis.com/auth/admin.directory.domain.readonly, https://www.googleapis.com/auth/admin.directory.user.readonly, https://www.googleapis.com/auth/admin.directory.group.readonly, https://www.googleapis.com/auth/admin.directory.user.security, https://www.googleapis.com/auth/apps.groups.settings
+   https://www.googleapis.com/auth/admin.directory.domain.readonly, https://www.googleapis.com/auth/admin.directory.user.readonly, https://www.googleapis.com/auth/admin.directory.group.readonly, https://www.googleapis.com/auth/admin.directory.user.security, https://www.googleapis.com/auth/apps.groups.settings, https://www.googleapis.com/auth/admin.directory.rolemanagement.readonly
    ```
 
 6. Click **Authorize**.
@@ -221,6 +221,7 @@ The following relationships are created/mapped:
 | Source Entity `_type` | Relationship `_class` | Target Entity `_type`          |
 | --------------------- | --------------------- | ------------------------------ |
 | `google_account`      | **HAS**               | `google_group`                 |
+| `google_account`      | **HAS**               | `google_role`                  |
 | `google_account`      | **HAS**               | `google_user`                  |
 | `google_group`        | **HAS**               | `google_group`                 |
 | `google_group`        | **HAS**               | `google_group_settings`        |

--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -209,6 +209,7 @@ The following entities are created:
 | Domain         | `google_domain`         | `Domain`        |
 | Group          | `google_group`          | `UserGroup`     |
 | Group Settings | `google_group_settings` | `Configuration` |
+| Role           | `google_role`           | `AccessRole`    |
 | Site           | `google_site`           | `Site`          |
 | Token          | `google_token`          | `AccessKey`     |
 | User           | `google_user`           | `User`          |

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -31,15 +31,15 @@ export const entities = {
     _type: 'google_group_settings',
     _class: 'Configuration',
   },
-  ROLE: {
-    resourceName: 'Role',
-    _type: 'google_role',
-    _class: 'AccessRole',
-  },
   ACCOUNT: {
     resourceName: 'Account',
     _type: 'google_account',
     _class: 'Account',
+  },
+  ROLE: {
+    resourceName: 'Role',
+    _type: 'google_role',
+    _class: 'AccessRole',
   },
   SITE: {
     resourceName: 'Site',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,6 +3,7 @@ import { RelationshipClass } from '@jupiterone/integration-sdk-core';
 export const Steps = {
   DOMAINS: 'step-fetch-domains',
   ACCOUNT: 'step-create-account',
+  ROLES: 'step-fetch-roles',
   USERS: 'step-fetch-users',
   TOKENS: 'step-fetch-tokens',
   GROUPS: 'step-fetch-groups',
@@ -30,6 +31,11 @@ export const entities = {
     _type: 'google_group_settings',
     _class: 'Configuration',
   },
+  ROLE: {
+    resourceName: 'Role',
+    _type: 'google_role',
+    _class: 'AccessRole',
+  },
   ACCOUNT: {
     resourceName: 'Account',
     _type: 'google_account',
@@ -53,6 +59,12 @@ export const relationships = {
     _class: RelationshipClass.HAS,
     sourceType: entities.ACCOUNT._type,
     targetType: entities.USER._type,
+  },
+  ACCOUNT_HAS_ROLE: {
+    _type: 'google_account_has_role',
+    _class: RelationshipClass.HAS,
+    sourceType: entities.ACCOUNT._type,
+    targetType: entities.ROLE._type,
   },
   SITE_HOSTS_USER: {
     _type: 'google_site_has_user',

--- a/src/gsuite/clients/GSuiteRoleClient.ts
+++ b/src/gsuite/clients/GSuiteRoleClient.ts
@@ -1,0 +1,36 @@
+import { admin_directory_v1 } from 'googleapis';
+import GSuiteAdminClient from './GSuiteAdminClient';
+import { CreateGSuiteClientParams } from './GSuiteClient';
+import Schema$Role = admin_directory_v1.Schema$Role;
+import Schema$Roles = admin_directory_v1.Schema$Roles;
+
+export class GSuiteRoleClient extends GSuiteAdminClient {
+  constructor(params: CreateGSuiteClientParams) {
+    super({
+      ...params,
+      requiredScopes: [
+        'https://www.googleapis.com/auth/admin.directory.rolemanagement.readonly',
+        ...(params.requiredScopes || []),
+      ],
+    });
+  }
+
+  public async iterateRoles(
+    callback: (data: Schema$Role) => Promise<void>,
+  ): Promise<void> {
+    const client = await this.getAuthenticatedServiceClient();
+
+    await this.iterateApi<Schema$Roles>(
+      async (pageToken) =>
+        client.roles.list({
+          customer: this.accountId,
+          pageToken,
+        }),
+      async (data) => {
+        for (const role of data.items || []) {
+          await callback(role);
+        }
+      },
+    );
+  }
+}

--- a/src/gsuite/clients/GSuiteRoleClient.ts
+++ b/src/gsuite/clients/GSuiteRoleClient.ts
@@ -22,10 +22,7 @@ export class GSuiteRoleClient extends GSuiteAdminClient {
 
     await this.iterateApi<Schema$Roles>(
       async (pageToken) =>
-        client.roles.list({
-          customer: this.accountId,
-          pageToken,
-        }),
+        client.roles.list({ customer: this.accountId, pageToken }),
       async (data) => {
         for (const role of data.items || []) {
           await callback(role);

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import validateInvocation from './validateInvocation';
 import { domainSteps } from './steps/domains';
 import { accountSteps } from './steps/account';
 import { userSteps } from './steps/users';
+import { roleSteps } from './steps/roles';
 import { groupSteps } from './steps/groups';
 import { tokenSteps } from './steps/tokens';
 
@@ -23,6 +24,7 @@ export const invocationConfig: IntegrationInvocationConfig<IntegrationConfig> = 
   validateInvocation,
   integrationSteps: [
     ...domainSteps,
+    ...roleSteps,
     ...accountSteps,
     ...userSteps,
     ...groupSteps,

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,8 +24,8 @@ export const invocationConfig: IntegrationInvocationConfig<IntegrationConfig> = 
   validateInvocation,
   integrationSteps: [
     ...domainSteps,
-    ...roleSteps,
     ...accountSteps,
+    ...roleSteps,
     ...userSteps,
     ...groupSteps,
     ...tokenSteps,

--- a/src/steps/roles/__recordings__/fetchRoles_3681693084/recording.har
+++ b/src/steps/roles/__recordings__/fetchRoles_3681693084/recording.har
@@ -1,0 +1,265 @@
+{
+  "log": {
+    "_recordingName": "fetchRoles",
+    "creator": {
+      "comment": "persister:JupiterOneIntegationFSPersister",
+      "name": "Polly.JS",
+      "version": "4.3.0"
+    },
+    "entries": [
+      {
+        "_id": "acea721c8193b51ced888cae721cc423",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 821,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "821"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "www.googleapis.com"
+            }
+          ],
+          "headersSize": 283,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "[REDACTED]"
+          },
+          "queryString": [],
+          "url": "https://www.googleapis.com/oauth2/v4/token"
+        },
+        "response": {
+          "bodySize": 586,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 586,
+            "text": "{\"access_token\":\"[REDACTED]\",\"expires_in\":9999,\"token_type\":\"Bearer\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "expires",
+              "value": "Mon, 01 Jan 1990 00:00:00 GMT"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 21 Sep 2021 19:59:22 GMT"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, no-store, max-age=0, must-revalidate"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "vary",
+              "value": "Origin, X-Origin, Referer"
+            },
+            {
+              "name": "server",
+              "value": "scaffolding on HTTPServer2"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "0"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-T051=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\""
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 630,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-21T19:59:22.027Z",
+        "time": 169,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 169
+        }
+      },
+      {
+        "_id": "dc146208d01001afc4cb62812e521a90",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-goog-api-client",
+              "value": "gdcl/4.4.0 gl-node/14.17.6 auth/6.0.6"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "google-api-nodejs-client/4.4.0 (gzip)"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "www.googleapis.com"
+            }
+          ],
+          "headersSize": 524,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://www.googleapis.com/admin/directory/v1/customer/C048tgq5f/roles"
+        },
+        "response": {
+          "bodySize": 3798,
+          "content": {
+            "mimeType": "application/json; charset=UTF-8",
+            "size": 3798,
+            "text": "{\"kind\":\"admin#directory#roles\",\"etag\":\"\\\"TelgxBbMU8DPRSlEKczQPr-k2OsjSql94v-H_DyiD8g/K3XBGLf6eY_jSApF9qNHny6TP0A\\\"\",\"items\":[{\"kind\":\"admin#directory#role\",\"etag\":\"\\\"TelgxBbMU8DPRSlEKczQPr-k2OsjSql94v-H_DyiD8g/p6QlXDm9MTGl_-YpfmD5G222-RU\\\"\",\"roleId\":\"50503969335672833\",\"roleName\":\"_SEED_ADMIN_ROLE\",\"roleDescription\":\"Google Workspace Administrator Seed Role\",\"rolePrivileges\":[{\"privilegeName\":\"SUPER_ADMIN\",\"serviceId\":\"01ci93xb3tmzyin\"},{\"privilegeName\":\"ROOT_APP_ADMIN\",\"serviceId\":\"01664s550kmxmin\"},{\"privilegeName\":\"ROOT_APP_ADMIN\",\"serviceId\":\"03j2qqm31d4j55e\"},{\"privilegeName\":\"ROOT_APP_ADMIN\",\"serviceId\":\"0319y80a15kueje\"},{\"privilegeName\":\"ROOT_APP_ADMIN\",\"serviceId\":\"03znysh70xi7xn7\"},{\"privilegeName\":\"ROOT_APP_ADMIN\",\"serviceId\":\"01ci93xb43sd8me\"},{\"privilegeName\":\"ROOT_APP_ADMIN\",\"serviceId\":\"00sqyw642iersp7\"},{\"privilegeName\":\"ROOT_APP_ADMIN\",\"serviceId\":\"03fwokq01e2ht7x\"},{\"privilegeName\":\"ROOT_APP_ADMIN\",\"serviceId\":\"00haapch16h1ysv\"},{\"privilegeName\":\"ROOT_APP_ADMIN\",\"serviceId\":\"03cqmetx3hnlpuf\"},{\"privilegeName\":\"ROOT_APP_ADMIN\",\"serviceId\":\"01tuee744837sjz\"},{\"privilegeName\":\"ROOT_APP_ADMIN\",\"serviceId\":\"037m2jsg3ckz96v\"},{\"privilegeName\":\"ROOT_APP_ADMIN\",\"serviceId\":\"03hv69ve4bjwe54\"},{\"privilegeName\":\"ROOT_APP_ADMIN\",\"serviceId\":\"01fob9te41qviqp\"},{\"privilegeName\":\"ROOT_APP_ADMIN\",\"serviceId\":\"02afmg282jiquyg\"},{\"privilegeName\":\"ROOT_APP_ADMIN\",\"serviceId\":\"02w5ecyt3pkeyqi\"},{\"privilegeName\":\"ROOT_APP_ADMIN\",\"serviceId\":\"019c6y1840fzfkt\"},{\"privilegeName\":\"ROOT_APP_ADMIN\",\"serviceId\":\"037m2jsg46www3g\"},{\"privilegeName\":\"ROOT_APP_ADMIN\",\"serviceId\":\"0147n2zr1ynkkmf\"},{\"privilegeName\":\"ROOT_APP_ADMIN\",\"serviceId\":\"00vx122734tbite\"},{\"privilegeName\":\"ROOT_APP_ADMIN\",\"serviceId\":\"03dy6vkm2sk0pzo\"},{\"privilegeName\":\"ROOT_APP_ADMIN\",\"serviceId\":\"02pta16n3efhw69\"},{\"privilegeName\":\"ROOT_APP_ADMIN\",\"serviceId\":\"01ksv4uv2d2noaq\"},{\"privilegeName\":\"ROOT_APP_ADMIN\",\"serviceId\":\"0279ka651l5iy5q\"},{\"privilegeName\":\"ROOT_APP_ADMIN\",\"serviceId\":\"00nmf14n14wtgcf\"},{\"privilegeName\":\"ROOT_APP_ADMIN\",\"serviceId\":\"01yyy98l4k9lq4l\"},{\"privilegeName\":\"ROOT_APP_ADMIN\",\"serviceId\":\"02zbgiuw2wdxo5p\"},{\"privilegeName\":\"ROOT_APP_ADMIN\",\"serviceId\":\"03as4poj2zjehv7\"},{\"privilegeName\":\"ROOT_APP_ADMIN\",\"serviceId\":\"03whwml44f3n4vd\"},{\"privilegeName\":\"ROOT_APP_ADMIN\",\"serviceId\":\"02u6wntf2pha1iq\"},{\"privilegeName\":\"ROOT_APP_ADMIN\",\"serviceId\":\"039kk8xu49mji9t\"},{\"privilegeName\":\"ROOT_APP_ADMIN\",\"serviceId\":\"02afmg283v5nmx6\"},{\"privilegeName\":\"ROOT_APP_ADMIN\",\"serviceId\":\"02bn6wsx379ol8g\"},{\"privilegeName\":\"ROOT_APP_ADMIN\",\"serviceId\":\"00tyjcwt49hs5nq\"},{\"privilegeName\":\"ROOT_APP_ADMIN\",\"serviceId\":\"02jxsxqh0hucks4\"},{\"privilegeName\":\"ROOT_APP_ADMIN\",\"serviceId\":\"00meukdy0whjvor\"},{\"privilegeName\":\"ROOT_APP_ADMIN\",\"serviceId\":\"02szc72q136h7dm\"}],\"isSystemRole\":true,\"isSuperAdminRole\":true},{\"kind\":\"admin#directory#role\",\"etag\":\"\\\"TelgxBbMU8DPRSlEKczQPr-k2OsjSql94v-H_DyiD8g/AZyBiFuT5UPygB11sJJRoC-J7xM\\\"\",\"roleId\":\"50503969335672834\",\"roleName\":\"_GROUPS_ADMIN_ROLE\",\"roleDescription\":\"Groups Administrator\",\"rolePrivileges\":[{\"privilegeName\":\"CHANGE_USER_GROUP_MEMBERSHIP\",\"serviceId\":\"01ci93xb3tmzyin\"},{\"privilegeName\":\"USERS_RETRIEVE\",\"serviceId\":\"00haapch16h1ysv\"},{\"privilegeName\":\"GROUPS_ALL\",\"serviceId\":\"00haapch16h1ysv\"},{\"privilegeName\":\"GROUPS_MANAGE_SECURITY_LABEL\",\"serviceId\":\"00haapch16h1ysv\"},{\"privilegeName\":\"ADMIN_DASHBOARD\",\"serviceId\":\"01ci93xb3tmzyin\"},{\"privilegeName\":\"ORGANIZATION_UNITS_RETRIEVE\",\"serviceId\":\"00haapch16h1ysv\"}],\"isSystemRole\":true},{\"kind\":\"admin#directory#role\",\"etag\":\"\\\"TelgxBbMU8DPRSlEKczQPr-k2OsjSql94v-H_DyiD8g/hBAEAUHZCvB-GooUsln7Fzlp450\\\"\",\"roleId\":\"50503969335672835\",\"roleName\":\"_GROUPS_READER_ROLE\",\"roleDescription\":\"Groups Reader\",\"rolePrivileges\":[{\"privilegeName\":\"GROUPS_RETRIEVE\",\"serviceId\":\"00haapch16h1ysv\"}],\"isSystemRole\":true},{\"kind\":\"admin#directory#role\",\"etag\":\"\\\"TelgxBbMU8DPRSlEKczQPr-k2OsjSql94v-H_DyiD8g/9xWSeKjDUuUW35WMV068-rmKsUA\\\"\",\"roleId\":\"50503969335672836\",\"roleName\":\"_GROUPS_EDITOR_ROLE\",\"roleDescription\":\"Groups Editor\",\"rolePrivileges\":[{\"privilegeName\":\"GROUPS_ALL\",\"serviceId\":\"00haapch16h1ysv\"}],\"isSystemRole\":true},{\"kind\":\"admin#directory#role\",\"etag\":\"\\\"TelgxBbMU8DPRSlEKczQPr-k2OsjSql94v-H_DyiD8g/kNWALX37rI5kSGEkxOct1DmTVws\\\"\",\"roleId\":\"50503969335672837\",\"roleName\":\"_USER_MANAGEMENT_ADMIN_ROLE\",\"roleDescription\":\"User Management Administrator\",\"rolePrivileges\":[{\"privilegeName\":\"USER_SECURITY_ALL\",\"serviceId\":\"00haapch16h1ysv\"},{\"privilegeName\":\"USERS_ALL\",\"serviceId\":\"00haapch16h1ysv\"},{\"privilegeName\":\"ADMIN_DASHBOARD\",\"serviceId\":\"01ci93xb3tmzyin\"},{\"privilegeName\":\"ORGANIZATION_UNITS_RETRIEVE\",\"serviceId\":\"00haapch16h1ysv\"}],\"isSystemRole\":true},{\"kind\":\"admin#directory#role\",\"etag\":\"\\\"TelgxBbMU8DPRSlEKczQPr-k2OsjSql94v-H_DyiD8g/jB4sW1FlaF-9mLW9Nxn7wXl4MRs\\\"\",\"roleId\":\"50503969335672838\",\"roleName\":\"_HELP_DESK_ADMIN_ROLE\",\"roleDescription\":\"Help Desk Administrator\",\"rolePrivileges\":[{\"privilegeName\":\"USERS_RESET_PASSWORD\",\"serviceId\":\"00haapch16h1ysv\"},{\"privilegeName\":\"USERS_RETRIEVE\",\"serviceId\":\"00haapch16h1ysv\"},{\"privilegeName\":\"ADMIN_DASHBOARD\",\"serviceId\":\"01ci93xb3tmzyin\"},{\"privilegeName\":\"ORGANIZATION_UNITS_RETRIEVE\",\"serviceId\":\"00haapch16h1ysv\"}],\"isSystemRole\":true},{\"kind\":\"admin#directory#role\",\"etag\":\"\\\"TelgxBbMU8DPRSlEKczQPr-k2OsjSql94v-H_DyiD8g/wMJ-24VQEw_ehczoMHkYmhCMoDM\\\"\",\"roleId\":\"50503969335672839\",\"roleName\":\"_SERVICE_ADMIN_ROLE\",\"roleDescription\":\"Services Administrator\",\"rolePrivileges\":[{\"privilegeName\":\"APP_ADMIN\",\"serviceId\":\"02zbgiuw2wdxo5p\"},{\"privilegeName\":\"APP_ADMIN\",\"serviceId\":\"01yyy98l4k9lq4l\"},{\"privilegeName\":\"APP_ADMIN\",\"serviceId\":\"00nmf14n14wtgcf\"},{\"privilegeName\":\"APP_ADMIN\",\"serviceId\":\"02afmg283v5nmx6\"},{\"privilegeName\":\"APP_ADMIN\",\"serviceId\":\"037m2jsg3ckz96v\"},{\"privilegeName\":\"LOGO_PRIVILEGE_GROUP\",\"serviceId\":\"03j2qqm31d4j55e\"},{\"privilegeName\":\"MANAGE_PLAY_FOR_WORK\",\"serviceId\":\"02w5ecyt3pkeyqi\"},{\"privilegeName\":\"APPS_INCIDENTS_FULL_ACCESS\",\"serviceId\":\"02pta16n3efhw69\"},{\"privilegeName\":\"APP_ADMIN\",\"serviceId\":\"039kk8xu49mji9t\"},{\"privilegeName\":\"APP_ADMIN\",\"serviceId\":\"0319y80a15kueje\"},{\"privilegeName\":\"APP_ADMIN\",\"serviceId\":\"01ci93xb43sd8me\"},{\"privilegeName\":\"ADMIN_DASHBOARD\",\"serviceId\":\"01ci93xb3tmzyin\"},{\"privilegeName\":\"ORGANIZATION_UNITS_RETRIEVE\",\"serviceId\":\"00haapch16h1ysv\"},{\"privilegeName\":\"DATATRANSFER_API_PRIVILEGE_GROUP\",\"serviceId\":\"00haapch16h1ysv\"},{\"privilegeName\":\"SERVICES\",\"serviceId\":\"01ci93xb3tmzyin\"},{\"privilegeName\":\"APP_ADMIN\",\"serviceId\":\"00sqyw642iersp7\"},{\"privilegeName\":\"MANAGE_DYNAMITE_SETTINGS\",\"serviceId\":\"03whwml44f3n4vd\"},{\"privilegeName\":\"MANAGE_DIRECTORY_SYNC_SETTINGS\",\"serviceId\":\"0147n2zr1ynkkmf\"},{\"privilegeName\":\"APP_ADMIN\",\"serviceId\":\"03cqmetx3hnlpuf\"},{\"privilegeName\":\"APP_ADMIN\",\"serviceId\":\"03dy6vkm2sk0pzo\"},{\"privilegeName\":\"APP_ADMIN\",\"serviceId\":\"03hv69ve4bjwe54\"},{\"privilegeName\":\"APP_ADMIN\",\"serviceId\":\"01tuee744837sjz\"},{\"privilegeName\":\"APP_ADMIN\",\"serviceId\":\"0279ka651l5iy5q\"},{\"privilegeName\":\"APP_ADMIN\",\"serviceId\":\"03fwokq01e2ht7x\"},{\"privilegeName\":\"APP_ADMIN\",\"serviceId\":\"01ksv4uv2d2noaq\"},{\"privilegeName\":\"APP_ADMIN\",\"serviceId\":\"037m2jsg46www3g\"},{\"privilegeName\":\"APP_ADMIN\",\"serviceId\":\"03as4poj2zjehv7\"},{\"privilegeName\":\"APP_ADMIN\",\"serviceId\":\"02afmg282jiquyg\"},{\"privilegeName\":\"APP_ADMIN\",\"serviceId\":\"019c6y1840fzfkt\"}],\"isSystemRole\":true},{\"kind\":\"admin#directory#role\",\"etag\":\"\\\"TelgxBbMU8DPRSlEKczQPr-k2OsjSql94v-H_DyiD8g/-VUt_Epm09X3gzjan--nvr0WWr0\\\"\",\"roleId\":\"50503969335672840\",\"roleName\":\"_MOBILE_ADMIN_ROLE\",\"roleDescription\":\"Mobile Administrator\",\"rolePrivileges\":[{\"privilegeName\":\"USERS_RETRIEVE\",\"serviceId\":\"00haapch16h1ysv\"},{\"privilegeName\":\"ADMIN_DASHBOARD\",\"serviceId\":\"01ci93xb3tmzyin\"},{\"privilegeName\":\"APP_ADMIN\",\"serviceId\":\"02afmg282jiquyg\"},{\"privilegeName\":\"GROUPS_RETRIEVE\",\"serviceId\":\"00haapch16h1ysv\"},{\"privilegeName\":\"ORGANIZATION_UNITS_RETRIEVE\",\"serviceId\":\"00haapch16h1ysv\"}],\"isSystemRole\":true},{\"kind\":\"admin#directory#role\",\"etag\":\"\\\"TelgxBbMU8DPRSlEKczQPr-k2OsjSql94v-H_DyiD8g/7CI_XrNQ2DG3vxh9B6jTVy217pI\\\"\",\"roleId\":\"50503969335672841\",\"roleName\":\"_THIRD_PARTY_DEVICE_MANAGEMENT_ADMIN_ROLE\",\"roleDescription\":\"This role is intended to be assigned to third party providers for updating/reading device metadata\",\"rolePrivileges\":[{\"privilegeName\":\"THIRD_PARTY_DEVICES_READONLY\",\"serviceId\":\"02afmg282jiquyg\"},{\"privilegeName\":\"THIRD_PARTY_DEVICES_FULL_ACCESS\",\"serviceId\":\"02afmg282jiquyg\"}],\"isSystemRole\":true},{\"kind\":\"admin#directory#role\",\"etag\":\"\\\"TelgxBbMU8DPRSlEKczQPr-k2OsjSql94v-H_DyiD8g/4JzL0LJxpRR3lhVvu2LPMFq3wlo\\\"\",\"roleId\":\"50503969335672842\",\"roleName\":\"JupiterOne System\",\"roleDescription\":\"Role for JupiterOne user to enable read-only access to Google Workspaces Admin APIs.\",\"rolePrivileges\":[{\"privilegeName\":\"API_APPS_ENTERPRISE_CUSTOMER_READ_PROFILE_SETTINGS\",\"serviceId\":\"00haapch16h1ysv\"},{\"privilegeName\":\"API_APPS_ENTERPRISE_CUSTOMER_UPDATE_PROFILE_SETTINGS\",\"serviceId\":\"00haapch16h1ysv\"},{\"privilegeName\":\"DOMAIN_MANAGEMENT\",\"serviceId\":\"00haapch16h1ysv\"},{\"privilegeName\":\"API_APPS_ENTERPRISE_CUSTOMER_UPDATE_ONBOARD_SETTINGS\",\"serviceId\":\"00haapch16h1ysv\"},{\"privilegeName\":\"API_APPS_ENTERPRISE_CUSTOMER_UPDATE_SUPPORT_SETTINGS\",\"serviceId\":\"00haapch16h1ysv\"},{\"privilegeName\":\"API_APPS_ENTERPRISE_CUSTOMER_UPDATE_TIME_ZONE_SETTINGS\",\"serviceId\":\"00haapch16h1ysv\"},{\"privilegeName\":\"API_APPS_ENTERPRISE_CUSTOMER_READ_BRANDING_SETTINGS\",\"serviceId\":\"00haapch16h1ysv\"},{\"privilegeName\":\"API_APPS_ENTERPRISE_CUSTOMER_READ_ONBOARD_SETTINGS\",\"serviceId\":\"00haapch16h1ysv\"},{\"privilegeName\":\"API_APPS_ENTERPRISE_CUSTOMER_READ_SUPPORT_SETTINGS\",\"serviceId\":\"00haapch16h1ysv\"},{\"privilegeName\":\"BILLING_READ\",\"serviceId\":\"00haapch16h1ysv\"},{\"privilegeName\":\"GROUPS_RETRIEVE\",\"serviceId\":\"00haapch16h1ysv\"},{\"privilegeName\":\"USER_SECURITY_ALL\",\"serviceId\":\"00haapch16h1ysv\"},{\"privilegeName\":\"API_APPS_ENTERPRISE_CUSTOMER_READ_TIME_ZONE_SETTINGS\",\"serviceId\":\"00haapch16h1ysv\"},{\"privilegeName\":\"USERS_RETRIEVE\",\"serviceId\":\"00haapch16h1ysv\"},{\"privilegeName\":\"API_APPS_ENTERPRISE_CUSTOMER_UPDATE_BRANDING_SETTINGS\",\"serviceId\":\"00haapch16h1ysv\"},{\"privilegeName\":\"ADMIN_DOMAIN_SETTINGS\",\"serviceId\":\"01ci93xb3tmzyin\"},{\"privilegeName\":\"ORGANIZATION_UNITS_RETRIEVE\",\"serviceId\":\"00haapch16h1ysv\"}]}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "etag",
+              "value": "\"TelgxBbMU8DPRSlEKczQPr-k2OsjSql94v-H_DyiD8g/K3XBGLf6eY_jSApF9qNHny6TP0A\""
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=UTF-8"
+            },
+            {
+              "name": "vary",
+              "value": "Origin, X-Origin, Referer"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 21 Sep 2021 19:59:22 GMT"
+            },
+            {
+              "name": "server",
+              "value": "ESF"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "0"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-T051=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\""
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 591,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-09-21T19:59:22.210Z",
+        "time": 194,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 194
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/steps/roles/__snapshots__/converters.test.ts.snap
+++ b/src/steps/roles/__snapshots__/converters.test.ts.snap
@@ -1,0 +1,51 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`#createRoleEntity should convert to entity 1`] = `
+Object {
+  "_class": Array [
+    "AccessRole",
+  ],
+  "_key": "google_role_123",
+  "_rawData": Array [
+    Object {
+      "name": "default",
+      "rawData": Object {
+        "isSuperAdminRole": false,
+        "isSystemRole": false,
+        "kind": "kind",
+        "roleDescription": "some role description",
+        "roleId": "123",
+        "roleName": "some role name",
+        "rolePrivileges": Array [
+          Object {
+            "privilegeName": "privilege1",
+            "serviceId": "abc",
+          },
+          Object {
+            "privilegeName": "privilege2",
+            "serviceId": "def",
+          },
+        ],
+      },
+    },
+  ],
+  "_type": "google_role",
+  "createdOn": undefined,
+  "description": "some role description",
+  "displayName": "some role name",
+  "id": "123",
+  "isAdmin": false,
+  "isSystem": false,
+  "kind": "kind",
+  "name": "some role name",
+  "privilegeIds": Array [
+    "abc",
+    "def",
+  ],
+  "privilegeNames": Array [
+    "privilege1",
+    "privilege2",
+  ],
+  "vendor": "Google",
+}
+`;

--- a/src/steps/roles/__snapshots__/converters.test.ts.snap
+++ b/src/steps/roles/__snapshots__/converters.test.ts.snap
@@ -34,17 +34,17 @@ Object {
   "description": "some role description",
   "displayName": "some role name",
   "id": "123",
-  "isAdmin": false,
+  "isSuperAdmin": false,
   "isSystem": false,
   "kind": "kind",
   "name": "some role name",
-  "privilegeIds": Array [
-    "abc",
-    "def",
-  ],
   "privilegeNames": Array [
     "privilege1",
     "privilege2",
+  ],
+  "privilegeServiceIds": Array [
+    "abc",
+    "def",
   ],
   "vendor": "Google",
 }

--- a/src/steps/roles/converters.test.ts
+++ b/src/steps/roles/converters.test.ts
@@ -1,0 +1,63 @@
+import {
+  createRoleEntity,
+  getRolePrivilegeStrings,
+  RolePrivilegeStrings,
+} from './converters';
+import { getMockRole } from '../../../test/mocks';
+import { admin_directory_v1 } from 'googleapis';
+import Schema$Role = admin_directory_v1.Schema$Role;
+
+describe('#getRolePrivilegeStrings', () => {
+  let role: Schema$Role;
+  let privileges: RolePrivilegeStrings;
+
+  beforeEach(() => {
+    role = getMockRole();
+
+    test('converts role.rolePrivileges to ids and names', () => {
+      expect(privileges).toEqual([
+        {
+          id: 'abc',
+          name: 'privilege1',
+        },
+        {
+          id: 'def',
+          privilegeName: 'privilege2',
+        },
+      ]);
+    });
+
+    test('it does not add falsy ids or names', () => {
+      role.rolePrivileges = [
+        { serviceId: undefined, privilegeName: 'privilege1' },
+        { serviceId: 'def', privilegeName: 'privilege2' },
+      ];
+      privileges = getRolePrivilegeStrings(role);
+
+      expect(privileges).toEqual([]);
+    });
+  });
+});
+
+describe('#createRoleEntity', () => {
+  const roleId = '123';
+  const roleName = 'some role name';
+  const description = 'some role description';
+
+  test('should convert to entity', () => {
+    expect(
+      createRoleEntity({
+        roleId,
+        roleName,
+        isSuperAdminRole: false,
+        isSystemRole: false,
+        kind: 'kind',
+        roleDescription: description,
+        rolePrivileges: [
+          { serviceId: 'abc', privilegeName: 'privilege1' },
+          { serviceId: 'def', privilegeName: 'privilege2' },
+        ],
+      }),
+    ).toMatchSnapshot();
+  });
+});

--- a/src/steps/roles/converters.ts
+++ b/src/steps/roles/converters.ts
@@ -17,6 +17,7 @@ export function getRolePrivilegeStrings(
       if (role.serviceId) privileges.privilegeIds.push(role.serviceId);
       if (role.privilegeName)
         privileges.privilegeNames.push(role.privilegeName);
+
       return privileges;
     },
     { privilegeIds: [], privilegeNames: [] } as RolePrivilegeStrings,

--- a/src/steps/roles/converters.ts
+++ b/src/steps/roles/converters.ts
@@ -5,7 +5,7 @@ import { admin_directory_v1 } from 'googleapis';
 import Schema$Role = admin_directory_v1.Schema$Role;
 
 export type RolePrivilegeStrings = {
-  privilegeIds: string[];
+  privilegeServiceIds: string[];
   privilegeNames: string[];
 };
 
@@ -14,13 +14,13 @@ export function getRolePrivilegeStrings(
 ): RolePrivilegeStrings {
   return (role.rolePrivileges || []).reduce(
     (privileges, role) => {
-      if (role.serviceId) privileges.privilegeIds.push(role.serviceId);
+      if (role.serviceId) privileges.privilegeServiceIds.push(role.serviceId);
       if (role.privilegeName)
         privileges.privilegeNames.push(role.privilegeName);
 
       return privileges;
     },
-    { privilegeIds: [], privilegeNames: [] } as RolePrivilegeStrings,
+    { privilegeServiceIds: [], privilegeNames: [] } as RolePrivilegeStrings,
   );
 }
 
@@ -28,7 +28,7 @@ export function createRoleEntity(role: Schema$Role) {
   const roleId = role.roleId as string;
   const roleName = role.roleName as string;
 
-  const { privilegeIds, privilegeNames } = getRolePrivilegeStrings(role);
+  const { privilegeServiceIds, privilegeNames } = getRolePrivilegeStrings(role);
 
   return createIntegrationEntity({
     entityData: {
@@ -42,8 +42,8 @@ export function createRoleEntity(role: Schema$Role) {
         displayName: roleName,
         description: role.roleDescription,
         isSystem: role.isSystemRole,
-        isAdmin: role.isSuperAdminRole,
-        privilegeIds,
+        isSuperAdmin: role.isSuperAdminRole,
+        privilegeServiceIds,
         privilegeNames,
         kind: role.kind,
         vendor: 'Google',

--- a/src/steps/roles/converters.ts
+++ b/src/steps/roles/converters.ts
@@ -1,0 +1,52 @@
+import generateEntityKey from '../../utils/generateEntityKey';
+import { entities } from '../../constants';
+import { createIntegrationEntity } from '@jupiterone/integration-sdk-core';
+import { admin_directory_v1 } from 'googleapis';
+import Schema$Role = admin_directory_v1.Schema$Role;
+
+export type RolePrivilegeStrings = {
+  privilegeIds: string[];
+  privilegeNames: string[];
+};
+
+export function getRolePrivilegeStrings(
+  role: Schema$Role,
+): RolePrivilegeStrings {
+  return (role.rolePrivileges || []).reduce(
+    (privileges, role) => {
+      if (role.serviceId) privileges.privilegeIds.push(role.serviceId);
+      if (role.privilegeName)
+        privileges.privilegeNames.push(role.privilegeName);
+      return privileges;
+    },
+    { privilegeIds: [], privilegeNames: [] } as RolePrivilegeStrings,
+  );
+}
+
+export function createRoleEntity(role: Schema$Role) {
+  const roleId = role.roleId as string;
+  const roleName = role.roleName as string;
+
+  const { privilegeIds, privilegeNames } = getRolePrivilegeStrings(role);
+
+  return createIntegrationEntity({
+    entityData: {
+      source: role,
+      assign: {
+        _class: entities.ROLE._class,
+        _type: entities.ROLE._type,
+        _key: generateEntityKey(entities.ROLE._type, roleId),
+        id: roleId,
+        name: roleName,
+        displayName: roleName,
+        description: role.roleDescription,
+        isSystem: role.isSystemRole,
+        isAdmin: role.isSuperAdminRole,
+        privilegeIds,
+        privilegeNames,
+        kind: role.kind,
+        vendor: 'Google',
+      },
+    },
+  });
+}

--- a/src/steps/roles/index.test.ts
+++ b/src/steps/roles/index.test.ts
@@ -30,7 +30,7 @@ describe('#fetchRoles', () => {
 
   const schema = {
     properties: {
-      isAdmin: {
+      isSuperAdmin: {
         description: 'Is the role an administrator role?',
         type: 'boolean',
       },

--- a/src/steps/roles/index.test.ts
+++ b/src/steps/roles/index.test.ts
@@ -28,12 +28,35 @@ describe('#fetchRoles', () => {
     return { accountEntity };
   }
 
-  test('success', async () => {
+  const schema = {
+    properties: {
+      isAdmin: {
+        description: 'Is the role an administrator role?',
+        type: 'boolean',
+      },
+      isSystem: {
+        description: 'Is this a system role?',
+        type: 'boolean',
+      },
+      privilegeIds: {
+        description: "The role's privileges",
+        type: 'array',
+        items: {
+          type: 'string',
+        },
+      },
+    },
+    required: [],
+  };
+
+  beforeEach(() => {
     recording = setupIntegrationRecording({
       directory: __dirname,
       name: 'fetchRoles',
     });
+  });
 
+  test('should collect data', async () => {
     const { accountEntity } = getSetupEntities();
     const context = createMockStepExecutionContext({
       instanceConfig: integrationConfig,
@@ -42,26 +65,6 @@ describe('#fetchRoles', () => {
 
     await fetchRoles(context);
     const roleEntities = context.jobState.collectedEntities;
-    const schema = {
-      properties: {
-        isAdmin: {
-          description: 'Is the role an administrator role?',
-          type: 'boolean',
-        },
-        isSystem: {
-          description: 'Is this a system role?',
-          type: 'boolean',
-        },
-        privilegeIds: {
-          description: "The role's privileges",
-          type: 'array',
-          items: {
-            type: 'string',
-          },
-        },
-      },
-      required: [],
-    };
 
     expect(roleEntities.length).toBeGreaterThan(0);
     expect(roleEntities).toMatchGraphObjectSchema({

--- a/src/steps/roles/index.test.ts
+++ b/src/steps/roles/index.test.ts
@@ -1,0 +1,76 @@
+import { createAccountEntity } from '../account/converters';
+import { integrationConfig } from '../../../test/config';
+import { setupIntegrationRecording } from '../../../test/recording';
+import {
+  createMockStepExecutionContext,
+  Recording,
+} from '@jupiterone/integration-sdk-testing';
+import { fetchRoles } from './index';
+import { entities } from '../../constants';
+
+let recording: Recording;
+
+afterEach(async () => {
+  if (recording) await recording.stop();
+});
+
+describe('#fetchRoles', () => {
+  function getSetupEntities() {
+    const accountEntity = createAccountEntity({
+      account: {
+        googleAccountId: integrationConfig.googleAccountId,
+        name: 'mygoogle',
+      },
+      domainNames: ['jupiterone.com', 'jupiterone.io'],
+      primaryDomain: 'jupiterone.com',
+    });
+
+    return { accountEntity };
+  }
+
+  test('success', async () => {
+    recording = setupIntegrationRecording({
+      directory: __dirname,
+      name: 'fetchRoles',
+    });
+
+    const { accountEntity } = getSetupEntities();
+    const context = createMockStepExecutionContext({
+      instanceConfig: integrationConfig,
+      entities: [accountEntity],
+    });
+
+    await fetchRoles(context);
+    const roleEntities = context.jobState.collectedEntities;
+    const schema = {
+      properties: {
+        isAdmin: {
+          description: 'Is the role an administrator role?',
+          type: 'boolean',
+        },
+        isSystem: {
+          description: 'Is this a system role?',
+          type: 'boolean',
+        },
+        privilegeIds: {
+          description: "The role's privileges",
+          type: 'array',
+          items: {
+            type: 'string',
+          },
+        },
+      },
+      required: [],
+    };
+
+    expect(roleEntities.length).toBeGreaterThan(0);
+    expect(roleEntities).toMatchGraphObjectSchema({
+      _class: entities.ROLE._class,
+      schema,
+    });
+
+    expect(context.jobState.collectedRelationships).toHaveLength(
+      roleEntities.length,
+    );
+  });
+});

--- a/src/steps/roles/index.ts
+++ b/src/steps/roles/index.ts
@@ -1,0 +1,47 @@
+import {
+  createDirectRelationship,
+  IntegrationStep,
+  RelationshipClass,
+} from '@jupiterone/integration-sdk-core';
+import { IntegrationConfig, IntegrationStepContext } from '../../types';
+import { entities, Steps } from '../../constants';
+import { createRoleEntity } from './converters';
+import { GSuiteRoleClient } from '../../gsuite/clients/GSuiteRoleClient';
+import { getAccountKey } from '../account/converters';
+
+export async function fetchRoles(
+  context: IntegrationStepContext,
+): Promise<void> {
+  const client = new GSuiteRoleClient({
+    config: context.instance.config,
+    logger: context.logger,
+  });
+
+  const accountKey = getAccountKey(context.instance.config.googleAccountId);
+  const accountEntity = await context.jobState.findEntity(accountKey);
+  if (!accountEntity)
+    throw new Error("fetchRoles: Couldn't find an account entity");
+
+  await client.iterateRoles(async (role) => {
+    const roleEntity = createRoleEntity(role);
+    await context.jobState.addEntity(roleEntity);
+
+    const relationship = createDirectRelationship({
+      from: accountEntity,
+      _class: RelationshipClass.HAS,
+      to: roleEntity,
+    });
+    await context.jobState.addRelationship(relationship);
+  });
+}
+
+export const roleSteps: IntegrationStep<IntegrationConfig>[] = [
+  {
+    id: Steps.ROLES,
+    name: 'Role',
+    entities: [entities.ROLE],
+    relationships: [],
+    dependsOn: [Steps.ACCOUNT],
+    executionHandler: fetchRoles,
+  },
+];

--- a/test/mocks.ts
+++ b/test/mocks.ts
@@ -74,3 +74,21 @@ export function getMockUser(
     ...partial,
   };
 }
+
+export function getMockRole(
+  partial?: Partial<admin_directory_v1.Schema$Role>,
+): admin_directory_v1.Schema$Role {
+  return {
+    kind: 'admin#directory#role',
+    roleId: '123456',
+    etag: 'abcdef',
+    roleName: 'some mocked role',
+    isSystemRole: false,
+    isSuperAdminRole: false,
+    rolePrivileges: [
+      { serviceId: 'abc', privilegeName: 'privilege1' },
+      { serviceId: 'def', privilegeName: 'privilege2' },
+    ],
+    ...partial,
+  };
+}


### PR DESCRIPTION
Ticket: https://jupiterone.atlassian.net/browse/INT-1715

This is part 1/2 of adding admin roles to `graph-google`. I am planning on handling further relationships/assignments in https://jupiterone.atlassian.net/browse/INT-1716.

Goes with: https://github.com/JupiterOne/data-model/pull/128