### PR TITLE
Release 3.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to
 
 ## [Unreleased]
 
-## 3.9.0 - 2021-09-22
+## 3.9.1 - 2021-09-27
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-google",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "description": "A JupiterOne managed integration for Google",
   "license": "MPL-2.0",
   "main": "dist/index.js",


### PR DESCRIPTION
I did not update the `CHANGELOG.md` entry description as this feature has not been deployed to production yet. 3.9.0 did get published to npm though so let me know if we prefer an additional `CHANGELOG.md` entry for this.

This patch version addresses some minor property naming preferences that were decided before deploying to production. See https://github.com/JupiterOne/graph-google/pull/123 for more info.