### PR TITLE
CORE-1834 - Make sure all target entity vendors have a _type specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,7 @@ and this project adheres to
 ### Changed
 
 - Entities created for targets of mapped `google_token_allows_mapped_vendor`
-  relationships will have a `_type` property of their vendor name in lowercase
-  with spaces replaced with `_`.
+  relationships will have a `_type`.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Entities created for targets of mapped `google_token_allows_mapped_vendor`
+  relationships will have a `_type` property of their vendor name in lowercase
+  with spaces replaced with `_`.
+
 ### Added
 
 - New properties added to resources:

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "ts-node": "^8.10.2"
   },
   "dependencies": {
+    "@jupiterone/vendor-stack": "^1.0.1",
     "gaxios": "^3.0.4",
     "googleapis": "^55.0.0"
   }

--- a/src/steps/tokens/index.ts
+++ b/src/steps/tokens/index.ts
@@ -40,6 +40,7 @@ export async function fetchTokens(
               tokenEntity,
             }),
           );
+          const vendorName = token.displayText || 'Unknown Vendor';
           await jobState.addRelationship(
             createMappedRelationship({
               _class: RelationshipClass.ALLOWS,
@@ -50,8 +51,9 @@ export async function fetchTokens(
                 targetFilterKeys: [['_class', 'name']],
                 targetEntity: {
                   _class: 'Vendor',
-                  displayName: token.displayText || 'Unknown Vendor',
-                  name: token.displayText || 'Unknown Vendor',
+                  _type: vendorName.toLowerCase().replace(' ', '_'),
+                  displayName: vendorName,
+                  name: vendorName,
                   validated: false,
                   active: true,
                 },

--- a/src/steps/tokens/index.ts
+++ b/src/steps/tokens/index.ts
@@ -12,6 +12,7 @@ import {
   createTokenEntity,
   createUserAssignedTokenRelationship,
 } from './converters';
+import { createVendorTypeFromName } from '@jupiterone/vendor-stack';
 
 export async function fetchTokens(
   context: IntegrationStepContext,
@@ -51,7 +52,7 @@ export async function fetchTokens(
                 targetFilterKeys: [['_class', 'name']],
                 targetEntity: {
                   _class: 'Vendor',
-                  _type: vendorName.toLowerCase().replace(' ', '_'),
+                  _type: createVendorTypeFromName(vendorName),
                   displayName: vendorName,
                   name: vendorName,
                   validated: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -608,6 +608,11 @@
     deepmerge "^4.2.2"
     lodash "^4.17.15"
 
+"@jupiterone/vendor-stack@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@jupiterone/vendor-stack/-/vendor-stack-1.0.1.tgz#292c6cd8914e36a7cfb07ec5368b86afa43ed5c7"
+  integrity sha512-87bT0v1HqEGP3z4RiMOGvSHxMGV1TU+fwhBEMQZ2Zgh1nyq0I3E5LiCO96iWGRaU3lEesG6St3/JLOx/9CUnMw==
+
 "@lifeomic/alpha@^1.4.0":
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/@lifeomic/alpha/-/alpha-1.4.1.tgz#fc3b8046f82c2b1bfaa15984f8d23eddbf7cbecf"


### PR DESCRIPTION
If you don't specify a _type for a target entity, the type will end up being `mapped_entity` which is wrong. We want the `_type` to be descriptive for vendors.