### PR TITLE
INT-2285 - Fix `google_mobile_device` duplicate `_key`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## 3.12.2 - 2021-12-16
+
+### Fixed
+
+- Fixed duplicate `_key` issue with `google_mobile_device`
+
 ## 3.12.1 - 2021-12-15
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-google",
-  "version": "3.12.1",
+  "version": "3.12.2",
   "description": "A JupiterOne managed integration for Google",
   "license": "MPL-2.0",
   "main": "dist/index.js",

--- a/src/steps/account/converters.ts
+++ b/src/steps/account/converters.ts
@@ -2,7 +2,7 @@ import generateEntityKey from '../../utils/generateEntityKey';
 import { entities } from '../../constants';
 import { createIntegrationEntity } from '@jupiterone/integration-sdk-core';
 
-interface CreateAccountEntityParams {
+export interface CreateAccountEntityParams {
   account: {
     googleAccountId: string;
     name: string;

--- a/src/steps/mobile_devices/__snapshots__/index.test.ts.snap
+++ b/src/steps/mobile_devices/__snapshots__/index.test.ts.snap
@@ -2,10 +2,47 @@
 
 exports[`#fetchMobileDevices should collect data 1`] = `
 Object {
-  "collectedEntities": Array [],
+  "collectedEntities": Array [
+    Object {
+      "_class": Array [
+        "Account",
+      ],
+      "_key": "google_account_C048tgq5f",
+      "_rawData": Array [
+        Object {
+          "name": "default",
+          "rawData": Object {
+            "account": Object {
+              "googleAccountId": "C048tgq5f",
+              "name": "mygoogle",
+            },
+            "domainNames": Array [
+              "jupiterone.com",
+              "jupiterone.io",
+            ],
+            "primaryDomain": "jupiterone.com",
+          },
+        },
+      ],
+      "_type": "google_account",
+      "accountId": "jupiterone.com",
+      "createdOn": undefined,
+      "displayName": "mygoogle",
+      "domains": Array [
+        "jupiterone.com",
+        "jupiterone.io",
+      ],
+      "id": "C048tgq5f",
+      "name": "mygoogle",
+      "primaryDomain": "jupiterone.com",
+      "vendor": "Google",
+    },
+  ],
   "collectedRelationships": Array [],
-  "encounteredTypes": Array [],
-  "numCollectedEntities": 0,
+  "encounteredTypes": Array [
+    "google_account",
+  ],
+  "numCollectedEntities": 1,
   "numCollectedRelationships": 0,
 }
 `;

--- a/src/steps/mobile_devices/index.test.ts
+++ b/src/steps/mobile_devices/index.test.ts
@@ -7,6 +7,7 @@ import { IntegrationConfig } from '../../types';
 import { fetchMobileDevices } from '.';
 import { integrationConfig } from '../../../test/config';
 import { entities } from '../../constants';
+import { getMockAccountEntity } from '../../../test/mocks';
 
 describe('#fetchMobileDevices', () => {
   let recording: Recording;
@@ -27,6 +28,15 @@ describe('#fetchMobileDevices', () => {
       instanceConfig: integrationConfig,
     });
 
+    await context.jobState.addEntity(
+      getMockAccountEntity({
+        account: {
+          googleAccountId: context.instance.config.googleAccountId,
+          name: 'mygoogle',
+        },
+      }),
+    );
+
     await fetchMobileDevices(context);
 
     expect({
@@ -37,7 +47,11 @@ describe('#fetchMobileDevices', () => {
       encounteredTypes: context.jobState.encounteredTypes,
     }).toMatchSnapshot();
 
-    expect(context.jobState.collectedEntities).toMatchGraphObjectSchema({
+    expect(
+      context.jobState.collectedEntities.filter(
+        (e) => e._type === entities.MOBILE_DEVICE._type,
+      ),
+    ).toMatchGraphObjectSchema({
       _class: entities.MOBILE_DEVICE._class,
       schema: {
         additionalProperties: true,

--- a/test/mocks.ts
+++ b/test/mocks.ts
@@ -1,4 +1,9 @@
+import { Entity } from '@jupiterone/integration-sdk-core';
 import { admin_directory_v1 } from 'googleapis';
+import {
+  createAccountEntity,
+  CreateAccountEntityParams,
+} from '../src/steps/account/converters';
 
 export function getMockUser(
   partial?: Partial<admin_directory_v1.Schema$User>,
@@ -91,4 +96,18 @@ export function getMockRole(
     ],
     ...partial,
   };
+}
+
+export function getMockAccountEntity(
+  partial?: Partial<CreateAccountEntityParams>,
+): Entity {
+  return createAccountEntity({
+    account: {
+      googleAccountId: 'abc',
+      name: 'mygoogle',
+    },
+    domainNames: ['jupiterone.com', 'jupiterone.io'],
+    primaryDomain: 'jupiterone.com',
+    ...partial,
+  });
 }


### PR DESCRIPTION
I'm not sure exactly why some entities are duplicates. We should be able to gather more useful from the raw data after this is deployed.