### PR TITLE
Release 3.12.5

### DIFF
--- a/jupiterone/questions/questions.yaml
+++ b/jupiterone/questions/questions.yaml
@@ -63,3 +63,16 @@ questions:
   - google
   - gsuite
   - user
+- id: integration-question-google-workspace-inactive-users-with-tokens
+  title: Do inactive Google Workspace users have any tokens assigned that allow them access to resources?
+  description:
+    Returns all tokens assigned to Google Workspace users that allow them access to resources.
+  queries:
+  - query: |
+      FIND google_user WITH active!=true OR archived!=false 
+        THAT ASSIGNED google_token 
+        THAT ALLOWS *
+  tags:
+  - google
+  - gsuite
+  - user 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-google",
-  "version": "3.12.4",
+  "version": "3.12.5",
   "description": "A JupiterOne managed integration for Google",
   "license": "MPL-2.0",
   "main": "src/index.js",


### PR DESCRIPTION
I didn't add questions or version in the last one 🤦.

This PR published version `3.12.5` of `graph-google` with:
- `code-ql` workflow
- `questions` workflow
- manged questions