### PR TITLE
INT-3992 - Updating Chrome Device Ingestion to handle 401/403 without Sentry Error

### DIFF
--- a/src/gsuite/clients/GSuiteChromeOSDeviceClient.ts
+++ b/src/gsuite/clients/GSuiteChromeOSDeviceClient.ts
@@ -19,12 +19,18 @@ export class GSuiteChromeOSDeviceClient extends GSuiteAdminClient {
   ): Promise<void> {
     const client = await this.getAuthenticatedServiceClient();
 
-    const response = await client.chromeosdevices.list({
-      customerId: this.accountId,
-    });
-
-    for (const device of response.data.chromeosdevices || []) {
-      await callback(device);
-    }
+    await this.iterateApi(
+      async (nextPageToken) => {
+        return client.chromeosdevices.list({
+          customerId: this.accountId,
+          pageToken: nextPageToken,
+        });
+      },
+      async (data: admin_directory_v1.Schema$ChromeOsDevices) => {
+        for (const device of data.chromeosdevices || []) {
+          await callback(device);
+        }
+      },
+    );
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -760,7 +760,7 @@
     upath "^1.2.0"
     vis "^4.21.0-EOL"
 
-"@jupiterone/integration-sdk-core@^8.12.10", "@jupiterone/integration-sdk-core@^8.13.10":
+"@jupiterone/integration-sdk-core@^8.13.10":
   version "8.13.10"
   resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-core/-/integration-sdk-core-8.13.10.tgz#98e14cd2381ab3d2eff2913b0620428c964d4af0"
   integrity sha512-sPpTbAUx5IiMYR35ixEZ2V94YIzONUctqIUxtupJqrkj29WtNXnncJMl4cX+fHixc8cd4MPyXL8O4lQILvS63A==


### PR DESCRIPTION
Updating Chrome Device ingestion to use shared `iterateApi` call.  This allows us to use the same logic for handling 401 and 403 errors in the same way as other steps.