### PR TITLE
INT-8944: fix errors

### DIFF
--- a/src/gsuite/clients/utils/createErrorProps.ts
+++ b/src/gsuite/clients/utils/createErrorProps.ts
@@ -8,8 +8,8 @@ type J1ApiErrorProps = GetConstructorArgs<
   typeof IntegrationProviderAPIError
 >[0];
 
-export function createErrorProps(error: Error | GaxiosError): J1ApiErrorProps {
-  if (error instanceof GaxiosError && error.response) {
+export function createErrorProps(error: GaxiosError): J1ApiErrorProps {
+  if (error.constructor.name === 'GaxiosError' && error.response) {
     return {
       cause: error,
       endpoint: error.response?.config?.url || UNKNOWN_VALUE,


### PR DESCRIPTION
Although Gaxios error constructor name is `GaxiosError`, the `error instanceof GaxiosError` check is always false. This is generating a big amount of useless error messages:

```
Error: Provider authorization failed at UNKNOWN: UNKNOWN UNKNOWN
```

Tried updating `googleapis` and `gaxios` but none of them worked. Moving forward by checking `error.constructor.name === 'GaxiosError'` That will achieve the same behaviour.